### PR TITLE
Use import from migrated package

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
     "release-it": "^2.3.1"
   },
   "dependencies": {
-    "@react-native-community/async-storage": "^1.4.0"
+    "@react-native-async-storage/async-storage": "^1.15.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-storage-engine-reactnativeasyncstorage",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "react-native/AsyncStorage based engine for redux-storage",
   "main": "build/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import AsyncStorage from '@react-native-community/async-storage';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 export default (key) => ({
     load() {


### PR DESCRIPTION
As stated in the blog post [Expo SDK 41](https://blog.expo.io/expo-sdk-41-12cc5232f2ef): `@react-native-community/async-storage` is now `@react-native-async-storage/async-storage`